### PR TITLE
GitLab: Create dedicated project for wiki

### DIFF
--- a/servers/gitlab/custom_wrapper.sh
+++ b/servers/gitlab/custom_wrapper.sh
@@ -47,7 +47,9 @@ echo "Finished importing all repos"
 curl --request POST --header "PRIVATE-TOKEN: root-token" \
      --header "Content-Type: application/json" --data '{
         "name": "Documentation", "description": "Wiki for company-wide doc", "path": "doc",
-        "initialize_with_readme": "true", "wiki_access_level": "enabled"}' \
+        "wiki_access_level": "enabled", "with_issues_enabled": "false",
+        "with_merge_requests_enabled": "false",
+        "visibility": "public"}' \
      --url "http://localhost:8929/api/v4/projects/"
 
 # TODO: change authorship of issues/prs/commits


### PR DESCRIPTION
As discussed in #14, we'd like to use GitLab wiki feature to host all company-wide documentation. This PR adds wiki project creation step into image build process.