### PR TITLE
[gitlab] Add infra and scripts to import wikis

### DIFF
--- a/servers/gitlab/Dockerfile
+++ b/servers/gitlab/Dockerfile
@@ -1,4 +1,5 @@
 FROM gitlab/gitlab-ce:17.3.1-ce.0
+RUN apt-get update && apt-get install -y jq && rm -rf /var/lib/apt/lists/*
 
 ENV GITLAB_SKIP_TAIL_LOGS=true
 ENV GITLAB_ROOT_EMAIL="root@local"
@@ -7,6 +8,9 @@ ENV GITLAB_ROOT_PASSWORD="JobBench"
 # Copy start script to the image
 # This script includes setting up GitLab and populating data
 COPY custom_wrapper.sh /assets
+
+# Copy wikis to the image
+COPY wikis /assets/wikis
 
 # Copy repo data to the image
 # "exports" folder contains all repos [reponame.tar.gz] in GitLab proprietary format


### PR DESCRIPTION
This adds a script that scans all markdown files under `wikis` directory and upload them to the "Documentation" project on GitLab, as part of the image build process.