### PR TITLE
[GitLab] Fix Dockerfile COPY command

### DIFF
--- a/servers/gitlab/Dockerfile
+++ b/servers/gitlab/Dockerfile
@@ -5,17 +5,8 @@ ENV GITLAB_SKIP_TAIL_LOGS=true
 ENV GITLAB_ROOT_EMAIL="root@local"
 ENV GITLAB_ROOT_PASSWORD="JobBench"
 
-# Copy start script to the image
-# This script includes setting up GitLab and populating data
-COPY custom_wrapper.sh /assets
-
-# Copy wikis to the image
-COPY wikis /assets/wikis
-
-# Copy repo data to the image
-# "exports" folder contains all repos [reponame.tar.gz] in GitLab proprietary format
-# they are exported manually from GitLab server(s)
-COPY exports /assets/exports
+# Copy start script and data to the image
+COPY . /assets
 
 RUN chmod +x /assets/custom_wrapper.sh
 CMD ["/assets/custom_wrapper.sh"]


### PR DESCRIPTION
Dockerfile COPY command doesn't allow you to copy an empty directory, so let's simply copy everything under gitlab folder.