### PR TITLE
[wiki] Add link to API server

### DIFF
--- a/servers/gitlab/wikis/Home.md
+++ b/servers/gitlab/wikis/Home.md
@@ -4,6 +4,5 @@ Welcome to NeuLab. This is the intro wiki to all company-wide doc.
 
 ## Useful Links
 
-Useful documentation show up here.
-
-This link [JobBench](https://github.com/neulab/JobBench) is to showcase you can use Markdown syntax here.
+[API Server](http://ogma.lti.cs.cmu.edu:8929/root/api-server) is the central API
+server that hosts all REST APIs used internally in the company.


### PR DESCRIPTION
Needed by the example task

Discussed with @frankxu2004 offline and we decided to use hard-coded hostname everywhere for now. Later we will use a fake URL and require all benchmark users to use `hosts` file to simulate a company private network setting.