### PR TITLE
Example task: Make init.sh finish

### DIFF
--- a/workspaces/tasks/example/init.sh
+++ b/workspaces/tasks/example/init.sh
@@ -15,6 +15,3 @@ python /npc/run_multi_npc.py
 ########## POST INIT PHASE ###########
 python /utils/post_init.py
 ######################################
-
-# optional: keep the container running
-tail -f /dev/null


### PR DESCRIPTION
Now that we have moved `init.sh` out of `Dockerfile`, there's no point to have

> tail -f /dev/null

to "keep the container running"