### PR TITLE
Gitlab rebuild command: Force rebuild

### DIFF
--- a/servers/Makefile
+++ b/servers/Makefile
@@ -100,7 +100,7 @@ rebuild-gitlab: init
 		echo "Image servers-gitlab does not exist. Skipping removal."; \
 	fi
 	@echo "start gitlab from clean state..."
-	docker-compose up --build --force-recreate gitlab -d
+	docker compose up --build --force-recreate gitlab -d
 
 # reset stops the gitlab container, destroys and starts again
 # any changes to gitlab will disappear, and the container will start


### PR DESCRIPTION
I've experienced this on ogma server. Due to some unknown reason, the image build process got stuck at a certain step. Without `force-recreate` flag, the `make rebuild-gitlab` got stuck at the same place every time.