### PR TITLE
Change python to python_default alias

### DIFF
--- a/USERDOC.md
+++ b/USERDOC.md
@@ -79,7 +79,7 @@ Once the examinee has finished its work (as of now, we don't enforce timing),
 run the below command in the exam container to grade the exam:
 
 ```bash
-python /utils/evaluator.py <optional_trajectory_file_path>
+python_default /utils/evaluator.py <optional_trajectory_file_path>
 ```
 
 Note that the trajectory file path must be an absolute path to the trajectory

--- a/workspaces/tasks/pm-add-new-moderator/init.sh
+++ b/workspaces/tasks/pm-add-new-moderator/init.sh
@@ -2,13 +2,13 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 ########## RUN INITIALIZATION ########
-python /utils/populate_data.py
+python_default /utils/populate_data.py
 ######################################
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/pm-assign-issues/init.sh
+++ b/workspaces/tasks/pm-assign-issues/init.sh
@@ -2,9 +2,9 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 ########## RUN INITIALIZATION ########
-python /utils/populate_data.py
+python_default /utils/populate_data.py
 ######################################

--- a/workspaces/tasks/pm-change-channel-ownership/init.sh
+++ b/workspaces/tasks/pm-change-channel-ownership/init.sh
@@ -2,12 +2,12 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 ########## RUN INITIALIZATION ########
 ######################################
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/pm-check-backlog-update-issues/init.sh
+++ b/workspaces/tasks/pm-check-backlog-update-issues/init.sh
@@ -2,7 +2,7 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 
@@ -13,5 +13,5 @@ python /npc/run_multi_npc.py
 
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/pm-create-channel-message/init.sh
+++ b/workspaces/tasks/pm-create-channel-message/init.sh
@@ -2,13 +2,13 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 ########## RUN INITIALIZATION ########
-python /utils/populate_data.py
+python_default /utils/populate_data.py
 ######################################
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/pm-create-channel-new-leader/init.sh
+++ b/workspaces/tasks/pm-create-channel-new-leader/init.sh
@@ -2,13 +2,13 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 ########## RUN INITIALIZATION ########
-python /utils/populate_data.py
+python_default /utils/populate_data.py
 ######################################
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/pm-create-plane-issue/init.sh
+++ b/workspaces/tasks/pm-create-plane-issue/init.sh
@@ -2,13 +2,13 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 ########## RUN INITIALIZATION ########
-python /utils/populate_data.py
+python_default /utils/populate_data.py
 ######################################
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/pm-send-hello-message/init.sh
+++ b/workspaces/tasks/pm-send-hello-message/init.sh
@@ -2,5 +2,5 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################

--- a/workspaces/tasks/pm-sprint-analytics/init.sh
+++ b/workspaces/tasks/pm-sprint-analytics/init.sh
@@ -2,5 +2,5 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################

--- a/workspaces/tasks/pm-update-sprint-cycles/init.sh
+++ b/workspaces/tasks/pm-update-sprint-cycles/init.sh
@@ -2,5 +2,5 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################

--- a/workspaces/tasks/repo_profile_pic/init.sh
+++ b/workspaces/tasks/repo_profile_pic/init.sh
@@ -2,7 +2,7 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 
@@ -12,5 +12,5 @@ python /utils/pre_init.py
 
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/sde-check-high-priority-issue/init.sh
+++ b/workspaces/tasks/sde-check-high-priority-issue/init.sh
@@ -2,13 +2,13 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 ########## RUN INITIALIZATION ########
-python /utils/populate_data.py
+python_default /utils/populate_data.py
 ######################################
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/sde-create-sqlite-database/init.sh
+++ b/workspaces/tasks/sde-create-sqlite-database/init.sh
@@ -2,10 +2,10 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/sde-milestone-meeting/init.sh
+++ b/workspaces/tasks/sde-milestone-meeting/init.sh
@@ -2,13 +2,13 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 ########## RUN INITIALIZATION ########
-python /utils/populate_data.py
+python_default /utils/populate_data.py
 ######################################
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################

--- a/workspaces/tasks/sde-summarize-recent-issues/init.sh
+++ b/workspaces/tasks/sde-summarize-recent-issues/init.sh
@@ -2,9 +2,9 @@
 set -ex
 
 ########## PRE INIT PHASE ############
-python /utils/pre_init.py
+python_default /utils/pre_init.py
 ######################################
 
 ########## POST INIT PHASE ###########
-python /utils/post_init.py
+python_default /utils/post_init.py
 ######################################


### PR DESCRIPTION
We ship an image for each task, and OpenHands builds a customized runtime image on top of it. Unfortunately, OpenHands by design would change the "python" alias and point it to their own version (which has all dependencies OpenHands runtime needs).

Solution is simple: always use `python_default` (our own python environment) instead of `python`.