### PR TITLE
GitLab: Change host url to synthetic hostname

### DIFF
--- a/servers/docker-compose.yml
+++ b/servers/docker-compose.yml
@@ -4,10 +4,10 @@ services:
       context: ./gitlab
     container_name: gitlab
     restart: always
-    hostname: '$HOSTNAME'
+    hostname: the-agent-company.com
     environment:
       GITLAB_OMNIBUS_CONFIG: |
-        external_url 'http://$HOSTNAME:$GITLAB_PORT'
+        external_url 'http://the-agent-company.com:$GITLAB_PORT'
         gitlab_rails['gitlab_shell_ssh_port'] = 2424
     ports:
       - '$GITLAB_PORT:8929'


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Use the synthetic domain, the-agent-company.com, instead of environmental variable $hostname in the server Makefile.

I already restarted gitlab and it works:

![image](https://github.com/user-attachments/assets/e7320108-9714-4fbb-a71b-fb21fdf39b4d)
