### PR TITLE
CI: make sure evaluator.py is runnable

### DIFF
--- a/.github/workflows/validate_task_images.yml
+++ b/.github/workflows/validate_task_images.yml
@@ -104,32 +104,41 @@ jobs:
           cd -
         done
 
+  test-evaluator-basic:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build base image
+      run: |
+        cd workspaces/base_image
+        make build
+
     - name: Run evaluator in each task container
       run: |
         for task_dir in workspaces/tasks/*/; do
           echo "Testing in $task_dir"
           cd "$task_dir"
-          
-          # Extract IMAGE_NAME and CONTAINER_NAME from Makefile
-          IMAGE_NAME=$(grep "^IMAGE_NAME" Makefile | cut -d '=' -f2 | tr -d ' ')
-          CONTAINER_NAME=$(grep "^CONTAINER_NAME" Makefile | cut -d '=' -f2 | tr -d ' ')
-          
+
+          docker build -t task-image .
+
           # Run the container and execute the evaluator
           # The evaluator would almost always say 0 marks granted, but that's
           # fine, we only run it to make sure it at least compiles
-          docker run --name $CONTAINER_NAME $IMAGE_NAME python /utils/evaluator.py
-          
+          docker run --rm task-image python_default /utils/evaluator.py
+
           # Capture the exit code
           EXIT_CODE=$?
-          
-          # Clean up
-          docker rm $CONTAINER_NAME
-          
+
           # If the evaluator failed, exit the workflow
           if [ $EXIT_CODE -ne 0 ]; then
             echo "Evaluator failed in $task_dir"
             exit $EXIT_CODE
           fi
-          
+
           cd -
         done


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

For every task, check if the evaluator.py is runnable.

Evaluators are designed to be stateless and shall succeed even if no action is taken to complete the task. They would very likely give 0 marks but that's perfectly fine. We just need to make sure they don't have syntax errors.

NOTE: this new GitHub Action is failing. Will create one or more follow-up PRs to fix the evaluator files, which might require some refactoring.
