### PR TITLE
Fix Dockerfile in repo_profile_pic

### DIFF
--- a/workspaces/tasks/repo_profile_pic/Dockerfile
+++ b/workspaces/tasks/repo_profile_pic/Dockerfile
@@ -5,5 +5,6 @@ RUN set -e && \
     curl -f -S -v -o /utils/reference.jpg https://images.pexels.com/photos/27220813/pexels-photo-27220813.jpeg && \
     [ -s /utils/reference.jpg ] || (echo "Failed to download image" && exit 1)
 
-# numpy library is needed for this task's evaluation
-RUN pip install numpy
+# numpy & pillow libraries are needed for this task's evaluation
+RUN pip install numpy==2.1.2
+RUN pip install pillow==11.0.0


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

repo_profile_pic task's evaluator needs PIL dependency but pillow is not specified in Dockerfile.

Fixing the dependency versions for better reproducibility.

