### PR TITLE
Hack for the incompatibility between Sotopia and Litellm

### DIFF
--- a/workspaces/base_image/npc/run_one_npc.py
+++ b/workspaces/base_image/npc/run_one_npc.py
@@ -17,6 +17,11 @@ os.environ['CUSTOM_API_KEY'] = os.getenv('LITELLM_API_KEY')
 BASE_URL = os.getenv('LITELLM_BASE_URL')
 MODEL_NAME = os.getenv('LITELLM_MODEL')
 
+# HACK: sotopia is not compatible with LITELLM, so we have to remove
+# "openai/" prefix, if any, from the model name.
+if MODEL_NAME.startswith("openai/"):
+    MODEL_NAME = MODEL_NAME[7:]  # Skip first 7 characters ("openai/")
+
 def main():
     # Use argparse to capture command-line arguments
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

We currently use [Sotopia](https://github.com/sotopia-lab/sotopia) to back NPCs. Unfortunately, Sotopia uses LangChain which is not 100% compatible with LiteLLM that we are using. Specifically, if one is using LiteLLM hosted API service, their model name would start with `openai/`, which is not recognized by LangChain.

This hack removes the "openai/" prefix if it exists before passing to Sotopia.

---
**Evidence/screenshots of getting full credits for evaluation (only if you create/modify a task)**
<img width="1215" alt="Screenshot 2024-10-23 at 7 38 33 PM" src="https://github.com/user-attachments/assets/f7900e64-516e-44dd-aceb-98e650a4c40b">


<img width="1022" alt="Screenshot 2024-10-23 at 7 37 39 PM" src="https://github.com/user-attachments/assets/d19ac835-9c86-4489-8ae4-00b6dba020c5">

---
**Any files modified/uploaded on the self-hosted services (if applicable)**
