### PR TITLE
infra: add new plane api key

### DIFF
--- a/servers/README.md
+++ b/servers/README.md
@@ -24,7 +24,7 @@ Below are the addresses, usernames, and passwords for each service:
 * http://ogma.lti.cs.cmu.edu:8091
 * email:`agent@company.com`
 * password:`theagentcompany`
-* API_KEY:`plane_api_759889ebd3744c96b3d9edcb0b013712`
+* API_KEY:`plane_api_83f868352c6f490aba59b869ffdae1cf`
 * If the API_KEY not work, ping @Yufan Song. And feel free to follow [here](https://developers.plane.so/api-reference/introduction) to create your temporary key to develop. We will always reset the server, so your temporary key may be deleted sometime after reset.
 
 ## RocketChat

--- a/workspaces/base_image/config.py
+++ b/workspaces/base_image/config.py
@@ -24,7 +24,7 @@ GITLAB_USER = "root"
 PLANE_PORT = os.getenv('PLANE_PORT') or '8091'
 PLANE_BASEURL = f"http://{SERVER_HOSTNAME}:{PLANE_PORT}"
 PLANE_WORKSPACE_SLUG = os.getenv("PLANE_WORKSPACE_SLUG") or "tac"
-PLANE_API_KEY = os.environ.get("PLANE_API_KEY") or "plane_api_569b8e604e0c46d0b65ef56bb9e76f03"
+PLANE_API_KEY = os.environ.get("PLANE_API_KEY") or "plane_api_83f868352c6f490aba59b869ffdae1cf"
 PLANE_HEADERS = {
     "x-api-key": PLANE_API_KEY,
     "Content-Type": "application/json"


### PR DESCRIPTION
Someone always report the api key is not valid. I think my backup and reset should be work. I redo it again. I do test and am sure this one works now. 

Let's see whether it will get invlide again.
I attach the secert key file here.
[secret-key-1730092042469.csv](https://github.com/user-attachments/files/17537746/secret-key-1730092042469.csv)
