### PR TITLE
Include all gitlab repositories in wiki

### DIFF
--- a/servers/gitlab/wikis/Home.md
+++ b/servers/gitlab/wikis/Home.md
@@ -4,10 +4,30 @@ Welcome to The Agent Company. This is the intro wiki to all company-wide doc.
 
 ## Useful Links
 
-[API Server](http://ogma.lti.cs.cmu.edu:8929/root/api-server) is the central API
+[API Server](http://the-agent-company.com:8929/root/api-server) is the central API
 server that hosts all REST APIs used internally in the company.
 
-[JanusGraph](http://ogma.lti.cs.cmu.edu:8929/root/janusgraph) is a distributed
+[BusTub](http://the-agent-company.com:8929/root/bustub) is an educational database.
+
+[Colly](http://the-agent-company.com:8929/root/colly) is a web scraping framework.
+
+[Copilot Arena Server](http://the-agent-company.com:8929/root/copilot-arena-server) is a server for Copilot Arena.
+
+[llama.cpp](http://the-agent-company.com:8929/root/llama.cpp) is LLM inference in C/C++.
+
+[node-red](http://the-agent-company.com:8929/root/node-red) is a low-code programming tool for event-driven applications.
+
+[opensearch](http://the-agent-company.com:8929/root/opensearch) is an open-source distributed and RESTful search engine.
+
+[raft](http://the-agent-company.com:8929/root/raft) is a research prototype of a distributed consensus algorithm.
+
+[RisingWave](http://the-agent-company.com:8929/root/risingwave) is an open-source distributed streaming database.
+
+[sotopia](http://the-agent-company.com:8929/root/sotopia) is an Open-ended Social Learning Environment.
+
+[Streamlit](http://the-agent-company.com:8929/root/streamlit) is an open-source app framework.
+
+[JanusGraph](http://the-agent-company.com:8929/root/janusgraph) is a distributed
 graph database.
 
-[OpenHands](http://ogma.lti.cs.cmu.edu:8929/root/openhands) is a LLM agent framework.
+[OpenHands](http://the-agent-company.com:8929/root/openhands) is a LLM agent framework.


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Some tasks point examinees to http://the-agent-company.com:8929/root/doc/-/wikis/home page and assume that wiki page contains links to repositories. This PR makes sure all repositories are listed on that page.
