### PR TITLE
OpenHands resolver: bump max iterations to 300

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -10,6 +10,7 @@ jobs:
     if: github.event.label.name == 'fix-me'
     with:
       issue_number: ${{ github.event.issue.number }}
+      max-iterations: 300
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
       PAT_USERNAME: ${{ secrets.PAT_USERNAME }}


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

OpenHands-resolver did a great job in #538 , but unfortunately it ran out of turns (by default it's 50 turns).

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
