### PR TITLE
[Evaluation] Add nextcloud login actions

### DIFF
--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -48,6 +48,10 @@ def get_config(
 def get_nextcloud_password():
     """
     Retrieves NEXTCLOUD_PASSWORD from the API endpoint
+
+    TODO: this is a temporary solution. Once #169 is solved,
+    we should be able to use a hard-coded password to avoid
+    this extra API call.
     
     Returns:
         str: The NEXTCLOUD_PASSWORD value
@@ -76,7 +80,23 @@ def get_nextcloud_password():
 
 
 def pre_login(runtime: Runtime, save_screenshots=True, screenshots_dir='screenshots'):
+    """
+    Logs in to all the websites that are needed for the evaluation.
+    Once logged in, the sessions would be cached in the browser, so OpenHands
+    agent doesn't need to log in to these websites again.
+
+    TODO: right now we assume all login actions succeed. We need to add some sanity
+    checks to ensure that login is successful.
+    """
     nextcloud_password = get_nextcloud_password()
+
+    nextcloud_login_actions = [
+        'goto("https://ogma.lti.cs.cmu.edu")',
+        'noop(5000)',
+        'fill("121", "admin")',
+        f'fill("126", "{nextcloud_password}")',
+        'click("134")'
+    ]
 
     rocketchat_login_actions = [
         'goto("http://the-agent-company.com:3000/")',
@@ -104,6 +124,7 @@ def pre_login(runtime: Runtime, save_screenshots=True, screenshots_dir='screensh
     ]
 
     all_login_actions = [
+        ('nextcloud', nextcloud_login_actions),
         ('rocket_chat', rocketchat_login_actions),
         ('gitlab', gitlab_login_actions),
         ('plane', plane_login_actions),


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**
1. Fetch NextCloud password from the remote API server (workaround before #169 is solved)
2. Add NextCloud login actions

Verified that login action succeeded (the screenshot is generated by OpenHands)
![4](https://github.com/user-attachments/assets/c1f16607-1f26-4915-b763-803c64801a7a)
