### PR TITLE
SDE Task: copy tables from pdf to xlsx

### DIFF
--- a/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/Dockerfile
+++ b/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/Dockerfile
@@ -1,0 +1,4 @@
+FROM base-image
+
+RUN pip install pandas==2.2.3
+RUN pip install openpyxl==3.1.5

--- a/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/Makefile
+++ b/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/Makefile
@@ -1,0 +1,14 @@
+IMAGE_NAME=sde-copy-table-from-pdf-to-xlsx-image
+CONTAINER_NAME=sde-copy-table-from-pdf-to-xlsx
+
+.PHONY: build run stop
+
+build:
+	docker build -t $(IMAGE_NAME) . --no-cache
+
+run:
+	docker run --name $(CONTAINER_NAME) -it $(IMAGE_NAME) /bin/bash 
+
+stop:
+	docker stop $(CONTAINER_NAME)
+	docker rm $(CONTAINER_NAME)

--- a/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/checkpoints.md
+++ b/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/checkpoints.md
@@ -1,0 +1,26 @@
+# Checkpoints
+
+This task has 5 checkpoints.
+
+## Checkpoint 1 (1pt)
+
+Found "link.txt" which contains a downloadable link to a xlsx file
+
+## Checkpoint 2 (1pt)
+
+In the first sheet, values in the PDF exist in the appropriate row and column for table 3
+
+
+## Checkpoint 3 (1pt)
+
+In the second sheet, values in the PDF exist in the appropriate row and column for table 4
+
+
+## Checkpoint 4 (1pt)
+
+In the third sheet, values in the PDF exist in the appropriate row and column for table 5
+
+
+## Checkpoint 5 (1pt)
+
+In the fourth sheet, alues in the PDF exist in the appropriate row and column for table 6

--- a/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/dependencies.yml
+++ b/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/dependencies.yml
@@ -1,0 +1,1 @@
+- nextcloud

--- a/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/evaluator.py
+++ b/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/evaluator.py
@@ -1,0 +1,88 @@
+import logging
+import numpy as np
+import pandas as pd
+
+from common import get_nextcloud_url_in_file, download_nextcloud_content
+from scoring import Result, Checkpoint, bonus_for_completing_final
+
+
+LINK_FILE = "/workspace/link.txt"
+LOCAL_DST = "/workspace/openhands_evaluation.xlsx"
+
+sheet1 = [
+    [["Lemur"], ["Lemur-chat-70b"], np.nan, 5.3, np.nan, np.nan],
+    [["CodeActAgent", "v1.8"], ["claude-3-5-sonnet"], 26.0, 15.3, 52.0, np.nan]
+]
+
+sheet2 = [
+    [["SWE-agent", "1-shot"], ["gpt-4-turbo"], 87.7, np.nan],
+    [["OH", "CodeActAgent", "v1.5"], ["gpt-3.5-turbo-16k-0613"], 20.1, 0.11]
+]
+
+sheet3 = [
+    [["WebArena", "Agent"], ["Llama3-chat-70b"], 7.0, np.nan],
+]
+
+sheet4 = [
+    [["OH", "CodeActAgent", "v1.5"], ["gpt-3.5-turbo-0125"], 11.8, 0.006]
+]
+
+def found_matching_row(df, sheet: list):
+    if df is None:
+        return False
+    try:
+        for entry in sheet:
+            column = 0
+            cond = True
+            for keywords in entry:
+                if isinstance(keywords, list):
+                    for key in keywords:
+                        cond &= df.iloc[:, column].str.contains(key, case=False)
+                elif np.isnan(keywords):
+                    cond &= df.iloc[:, column].isna()
+                else:
+                    cond &= df.iloc[:, column] == keywords
+
+                column += 1
+            matching_rows = df[cond]
+            if matching_rows.empty:
+                return False
+    except Exception as e:
+        logging.error("Error finding matching row: %s", e)
+    return True
+
+def read_sheet(sheet_index: int):
+    try:
+        df = pd.read_excel(LOCAL_DST, sheet_name=sheet_index)
+    except Exception as e:
+        logging.error("Error reading sheet %s: %s", sheet_index, e)
+        return None
+    return df
+
+def grade_checkpoint1(link):
+    if not link:
+        return False
+    return True
+
+def grade_checkpoint2():
+    return found_matching_row(read_sheet(0), sheet1)
+
+def grade_checkpoint3():
+    return found_matching_row(read_sheet(1), sheet2)
+
+def grade_checkpoint4():
+    return found_matching_row(read_sheet(2), sheet3)
+
+def grade_checkpoint5():
+    return found_matching_row(read_sheet(3), sheet4)
+
+def grade_checkpoints(trajectory="") -> Result:
+    xlsx_link = get_nextcloud_url_in_file(LINK_FILE)
+    download_nextcloud_content(xlsx_link, LOCAL_DST)
+    checkpoint1 = Checkpoint(1, 1*int(grade_checkpoint1(xlsx_link)))
+    checkpoint2 = Checkpoint(1, 1*int(grade_checkpoint2()))
+    checkpoint3 = Checkpoint(1, 1*int(grade_checkpoint3()))
+    checkpoint4 = Checkpoint(1, 1*int(grade_checkpoint4()))
+    checkpoint5 = Checkpoint(1, 1*int(grade_checkpoint5()))
+    return Result([checkpoint1, checkpoint2, checkpoint3, checkpoint4, checkpoint5])
+

--- a/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/task.md
+++ b/workspaces/tasks/sde-copy-table-from-pdf-to-xlsx/task.md
@@ -1,0 +1,3 @@
+There is a PDF file OpenHands.pdf on NextCloud ("https://ogma.lti.cs.cmu.edu/apps/files/files/1864?dir=/Documents/Research").
+Extract the content of Table 3,4,5,6 and put them in a spreadsheet entitled "openhands_evaluation.xlsx" in the same directory on NextCloud. Each table should be a separate sheet in the spreadsheet.
+After you upload the xlsx file to NextCloud, create a share link to the file and write it in "/workspace/link.txt" in local storage. "link.txt" should only contain the link and nothing else.


### PR DESCRIPTION
Task.md:
```
There is a PDF file OpenHands.pdf on NextCloud ("https://ogma.lti.cs.cmu.edu/apps/files/files/1864?dir=/Documents/Research").
Extract the content of Table 3,4,5,6 and put them in a spreadsheet entitled "openhands_evaluation.xlsx" in the same directory on NextCloud. Each table should be a separate sheet in the spreadsheet.
After you upload the xlsx file to NextCloud, create a share link to the file and write it in "/workspace/link.txt" in local storage. "link.txt" should only contain the link and nothing else.
```

There are 5 checkpoints. The first one validate "/workspace/link.txt". The rest four check correctness of four tables in the generated sheet. Only sample data are used to validate the data.

- Full credit
![image](https://github.com/user-attachments/assets/0230530b-cd2d-432a-b155-43744ca24880)

xlsx file uploaded to NextCloud:
![image](https://github.com/user-attachments/assets/dbae1310-be5d-43c0-aa4d-a58b9e326e69)

Script to create a xlsx file that passes all checkpoints (credit to OpenHands)
```python
import pandas as pd
import numpy as np
from io import BytesIO

# Create a Pandas Excel writer using xlsxwriter
writer = pd.ExcelWriter('openhands_evaluation.xlsx', engine='xlsxwriter')

# Table 1: Overall Performance (tab:overall_perf)
overall_perf = pd.DataFrame({
    'Agent': [
        'SWE-Agent', 'AutoCodeRover', 'Aider', 'Moatless Tools', 'Agentless',
        'Lemur', 'Patel et al.', 'AutoWebGLM', 'Auto Eval & Refine', 'WebArena Agent',
        'AutoGPT',
        'Few-shot Prompting + Chain-of-Thought (Llama-2-70b-chat)',
        'Few-shot Prompting + Chain-of-Thought (gpt-3.5-turbo-16k)',
        'Few-shot Prompting + Chain-of-Thought (gpt-4)',
        'CodeActAgent v1.8 (gpt-4o-mini-2024-07-18)',
        'CodeActAgent v1.8 (gpt-4o-2024-05-13)',
        'CodeActAgent v1.8 (claude-3-5-sonnet)',
        'GPTSwarm v1.0'
    ],
    'Model': [
        'gpt-4-1106-preview', 'gpt-4-0125-preview', 'gpt-4o & claude-3-opus', 'claude-3.5-sonnet', 'gpt-4o',
        'Lemur-chat-70b', 'Trained 72B w/ synthetic data', 'Trained 7B w/ human/agent annotation', 'GPT-4 + Reflexion w/ GPT-4V', 'gpt-4-turbo',
        'gpt-4-turbo',
        'Llama-2-70b-chat', 'gpt-3.5-turbo-16k', 'gpt-4',
        'gpt-4o-mini-2024-07-18', 'gpt-4o-2024-05-13', 'claude-3-5-sonnet', 'gpt-4o-2024-05-13'
    ],
    'SWE-Bench Lite': [18.0, 19.0, 26.3, 26.7, 27.3, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 6.3, 22.0, 26.0, np.nan],
    'WebArena': [np.nan, np.nan, np.nan, np.nan, np.nan, 5.3, 9.4, 18.2, 20.2, 14.4, np.nan, np.nan, np.nan, np.nan, 8.3, 14.5, 15.3, np.nan],
    'GPQA': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 28.1, 29.6, 38.8, np.nan, 53.1, 52.0, np.nan],
    'GAIA': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 13.2, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 32.1]
})

# Table 2: Software Engineering Results (tab:swe_bench)
swe_bench = pd.DataFrame({
    'Agent': [
        'SWE-Agent', 'AutoCodeRover', 'Aider', 
        'OH CodeActAgent v1.8 (gpt-4o-mini)', 'OH CodeActAgent v1.8 (gpt-4o)', 'OH CodeActAgent v1.8 (claude-3.5-sonnet)',
        'Prompting BLOOMZ-176B', 'Prompting OctoCoder-15B', 'Prompting DeepSeekCoder-33B-Instruct', 'Prompting StarCoder2-15B',
        'SWE-agent 1-shot', 'OH CodeActAgent v1.5 (gpt-3.5-turbo-16k)', 'OH CodeActAgent v1.5 (gpt-4o)'
    ],
    'Model': [
        'gpt-4-1106-preview', 'gpt-4-0125-preview', 'gpt-4o & claude-3-opus',
        'gpt-4o-mini-2024-07-18', 'gpt-4o-2024-05-13', 'claude-3-5-sonnet@20240620',
        'BLOOMZ-176B', 'OctoCoder-15B', 'DeepSeekCoder-33B-Instruct', 'StarCoder2-15B',
        'gpt-4-turbo', 'gpt-3.5-turbo-16k-0613', 'gpt-4o-2024-05-13'
    ],
    'Success Rate (%)': [18.0, 19.0, 26.3, 7.0, 22.0, 26.0, 16.6, 30.4, 47.5, 48.6, 87.7, 20.1, 79.3],
    'Average Cost ($)': [1.67, np.nan, np.nan, 0.01, 1.72, 1.10, np.nan, np.nan, np.nan, np.nan, np.nan, 0.11, 0.14]
})

# Table 3: Web Browsing Results (tab:web_browsing)
web_browsing = pd.DataFrame({
    'Agent': [
        'Lemur', 'Patel et al.', 'AutoWebGLM', 'Auto Eval & Refine',
        'WebArena Agent (Llama3-chat-8b)', 'WebArena Agent (Llama3-chat-70b)', 
        'WebArena Agent (gpt-3.5-turbo)', 'WebArena Agent (gpt-4-turbo)',
        'OH BrowsingAgent v1.0 (gpt-3.5-turbo)', 'OH BrowsingAgent v1.0 (gpt-4o-mini)',
        'OH BrowsingAgent v1.0 (gpt-4o)', 'OH BrowsingAgent v1.0 (claude-3.5-sonnet)',
        'OH CodeActAgent v1.8 (gpt-4o-mini)', 'OH CodeActAgent v1.8 (gpt-4o)',
        'OH CodeActAgent v1.8 (claude-3.5-sonnet)'
    ],
    'Model': [
        'Lemur-chat-70b', 'Trained 72B', 'Trained 7B', 'GPT-4 + Reflexion',
        'Llama3-chat-8b', 'Llama3-chat-70b', 'gpt-3.5-turbo', 'gpt-4-turbo',
        'gpt-3.5-turbo-0125', 'gpt-4o-mini-2024-07-18', 'gpt-4o-2024-05-13', 'claude-3-5-sonnet-20240620',
        'gpt-4o-mini-2024-07-18', 'gpt-4o-2024-05-13', 'claude-3-5-sonnet-20240620'
    ],
    'Success Rate (%)': [5.3, 9.4, 18.2, 20.2, 3.3, 7.0, 6.2, 14.4, 5.2, 8.5, 14.8, 15.5, 8.3, 14.5, 15.3],
    'Average Cost ($)': [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, 0.02, 0.01, 0.15, 0.10, np.nan, np.nan, np.nan]
})

# Table 4: Miscellaneous Assistance Results (tab:misc_assistance)
misc_assistance = pd.DataFrame({
    'Agent': [
        'AutoGPT', 'OH GPTSwarm v1.0 (gpt-4-0125)', 'OH GPTSwarm v1.0 (gpt-4o)',
        'Human Expert', 'Human Non-expert',
        'Few-shot Prompting + CoT (gpt-3.5-turbo-16k)', 'Few-shot Prompting + CoT (gpt-4)',
        'OH CodeActAgent v1.8 (claude-3.5-sonnet)',
        'AgentBench Baseline (gpt-4)', 'AgentBench Baseline (gpt-3.5-turbo)',
        'OH CodeActAgent v1.5 (gpt-4o)', 'OH CodeActAgent v1.5 (gpt-3.5-turbo)'
    ],
    'Model': [
        'gpt-4-turbo', 'gpt-4-0125-preview', 'gpt-4o-2024-05-13',
        'Expert human', 'Non-expert human',
        'gpt-3.5-turbo-16k', 'gpt-4',
        'claude-3-5-sonnet-20240620',
        'gpt-4', 'gpt-3.5-turbo',
        'gpt-4o-2024-05-13', 'gpt-3.5-turbo-0125'
    ],
    'Success Rate (%)': [13.2, 30.2, 32.1, 81.3, 21.9, 29.6, 38.8, 52.0, 42.4, 32.6, 57.6, 11.8],
    'Average Cost ($)': [np.nan, 0.110, 0.050, np.nan, np.nan, np.nan, np.nan, 0.065, np.nan, np.nan, 0.085, 0.006]
})

# Write each dataframe to a different sheet in the Excel file
overall_perf.to_excel(writer, sheet_name='Overall Performance', index=False)
swe_bench.to_excel(writer, sheet_name='Software Engineering', index=False)
web_browsing.to_excel(writer, sheet_name='Web Browsing', index=False)
misc_assistance.to_excel(writer, sheet_name='Misc Assistance', index=False)

writer.close()
```

- Failed case
![image](https://github.com/user-attachments/assets/0c395e44-2677-4439-880e-4aafdf21518a)
