### PR TITLE
[Evaluation] Fix wrong nextcloud password used in evaluator

### DIFF
--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -167,7 +167,7 @@ def run_solver(runtime: Runtime, task_name: str, config: AppConfig) -> State:
 
 def run_evaluator(runtime: Runtime, llm_config: LLMConfig, nextcloud_password: str, trajectory_path: str, result_path: str):
     command = (
-        f"NEXTCLOUD_PASSWORD={nextcloud_password} "
+        f"NEXTCLOUD_ADMIN_PASSWORD={nextcloud_password} "
         f"LITELLM_API_KEY={llm_config.api_key} "
         f"LITELLM_BASE_URL={llm_config.base_url} "
         f"LITELLM_MODEL={llm_config.model} "


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

I was running evaluation and found `hr-salary-analysis` & `hr-populate-salary-increase-memo` task failed because the NEXTCLOUD password used in evaluator was wrong. Turns out I passed the wrong environmental variable to evaluator.