### PR TITLE
[CI] Use current PR context for evaluation

### DIFF
--- a/.github/workflows/benchmark-runner.yml
+++ b/.github/workflows/benchmark-runner.yml
@@ -11,7 +11,8 @@ concurrency:
 
 jobs:
   run-evaluation:
-    if: startsWith(github.event.comment.body, '/run-eval')
+    # First check if this is a PR comment
+    if: ${{ startsWith(github.event.comment.body, '/run-eval') && github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -25,6 +26,23 @@ jobs:
           TASK_NAME=$(echo "$COMMENT" | sed -n 's/^\/run-eval \(.*\)/\1/p')
           echo "task_name=$TASK_NAME" >> $GITHUB_OUTPUT
           
+      # Get the PR data
+      - name: Get PR Data
+        uses: actions/github-script@v7
+        id: pr
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            return {
+              ref: pr.data.head.ref,
+              sha: pr.data.head.sha,
+              repo: pr.data.head.repo.full_name
+            }
+
       - name: Add reaction to comment
         uses: peter-evans/create-or-update-comment@v3
         with:
@@ -38,10 +56,12 @@ jobs:
           body: |
             Started evaluation! You can monitor the progress [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-      - name: Checkout repository
+      # Checkout the PR code
+      - name: Checkout PR
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ fromJSON(steps.pr.outputs.result).repo }}
+          ref: ${{ fromJSON(steps.pr.outputs.result).sha }}
           fetch-depth: 0
 
       - name: Setup Python


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Instead of using main branch's latest code for evaluation when `/run-eval` is issued, this PR aims to make GitHub Actions run evaluation against every PR's context.

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
