### PR TITLE
Fix service health check endpoint

### DIFF
--- a/servers/api-server/server.py
+++ b/servers/api-server/server.py
@@ -8,6 +8,7 @@ import requests
 
 app = Flask(__name__)
 
+# TODO (yufansong): using git to find root is hacky and wrong
 def get_git_root():
     try:
         git_root = subprocess.check_output(
@@ -88,7 +89,8 @@ def healthcheck_gitlab():
 
 @app.route('/api/healthcheck/nextcloud', methods=['GET'])
 def healthcheck_nextcloud():
-    code, msg = check_url("http://localhost:8090")
+    # TODO (yufansong): either fix SSL issue, or pass this address from outside
+    code, msg = check_url("https://ogma.lti.cs.cmu.edu")
     return jsonify({"message":msg}), code
 
 @app.route('/api/healthcheck/rocketchat', methods=['GET'])


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

NextCloud health check has to rely on the external https address until @frankxu2004 and/or @yufansong fix https://github.com/neulab/TheAgentCompany/issues/170

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
