### PR TITLE
fix: change nextcloud url

### DIFF
--- a/workspaces/base_image/config.py
+++ b/workspaces/base_image/config.py
@@ -10,7 +10,7 @@ LITELLM_BASE_URL = os.environ.get("LITELLM_BASE_URL", "https://api.openai.com/v1
 LITELLM_MODEL = os.environ.get("LITELLM_MODEL", "gpt-4o")
 
 # Nextcloud Config
-NEXTCLOUD_URL = os.environ.get("NEXTCLOUD_URL", "https://ogma.lti.cs.cmu.edu")
+NEXTCLOUD_URL = os.environ.get("NEXTCLOUD_URL", "https://ogma.lti.cs.cmu.edu/login")
 NEXTCLOUD_USERNAME = 'admin'
 NEXTCLOUD_PASSWORD = os.environ.get('NEXTCLOUD_ADMIN_PASSWORD')
 


### PR DESCRIPTION
From auto evaluation, it seems like agents are sometimes accessing incorrect nextcloud url
![Screenshot 2024-11-13 at 5 07 24 PM](https://github.com/user-attachments/assets/3082a2a4-c791-456e-a7fb-5f2b9b33df3b)
