### PR TITLE
[Evaluation] Remove last step in rocketchat pre-login action

### DIFF
--- a/evaluation/browsing.py
+++ b/evaluation/browsing.py
@@ -193,7 +193,8 @@ def pre_login(runtime: Runtime, services: List[str], nextcloud_password: str, sa
         ClickAction("button 'Login', clickable"),
         NoopAction(1000),
         # after login, a popup asking to change hostname appears. We need to click on cancel button.
-        ClickAction("button 'Cancel', clickable")
+        # FIXME: this seems useless. Plus, it interferes with developers' activities.
+        # ClickAction("button 'Cancel', clickable")
     ]
 
     gitlab_login_actions = [


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Have to remove it because sometimes when developers use Rocketchat concurrently, this window might not appear, causing evaluator's pre-login action to fail.

Plus, it seems useless? I sometimes (maybe always, not sure) still see CodeActAgent clicking on "cancel" again, from the trajectory.

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
