### PR TITLE
[Evaluation] Use host.docker.internal as default host

### DIFF
--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -162,8 +162,9 @@ if __name__ == '__main__':
     parser.add_argument(
         '--server-hostname',
         type=str,
-        default='localhost',
-        help='Server hostname, e.g. localhost'
+        default='host.docker.internal',
+        help='Server hostname, e.g. host.docker.internal to access the host machine from the container, '
+        'assuming the task docker container is run with --add-host=host.docker.internal:host-gateway flag'
     )
     args, _ = parser.parse_known_args()
 

--- a/evaluation/run_eval.sh
+++ b/evaluation/run_eval.sh
@@ -19,7 +19,7 @@ LLM_CONFIG="claude"
 OUTPUTS_PATH="outputs"
 # SERVER_HOSTNAME is the hostname of the server that hosts all the web services,
 # including RocketChat, ownCloud, GitLab, and Plane.
-SERVER_HOSTNAME="localhost"
+SERVER_HOSTNAME="host.docker.internal"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do

--- a/workspaces/base_image/init.sh
+++ b/workspaces/base_image/init.sh
@@ -5,7 +5,7 @@ set -e
 
 # Use synthetic service hostname, the-agent-company.com in tasks and point it
 # to the real service host
-SERVICE_IP=$(ping -c 1 ${SERVER_HOSTNAME:-localhost} | grep PING | awk -F'[()]' '{print $2}')
+SERVICE_IP=$(ping -c 1 ${SERVER_HOSTNAME:-host.docker.internal} | grep PING | awk -F'[()]' '{print $2}')
 echo "$SERVICE_IP the-agent-company.com" >> /etc/hosts
 
 # Reset services if declared as a dependency


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

For convenience and due to various technical blockers, we used to use ogma.lti.cs.cmu.edu as default or hardcoded hostname. This PR replaces ogma host with "host.docker.internal", the alias for the host inside a docker container.

One exception is `benchmark-runner.yml`: https://github.com/neulab/TheAgentCompany/blob/be0753932054118a9a996ff380c8e33bc251b961/.github/workflows/benchmark-runner.yml#L108 which uses ogma.lti.cs.cmu.edu machine, since CI environment has no servers hosted

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
