### PR TITLE
[fix] sotopia agent debug message appear in #general

### DIFF
--- a/workspaces/base_image/npc/rocketchat_agent.py
+++ b/workspaces/base_image/npc/rocketchat_agent.py
@@ -115,7 +115,7 @@ class RocketChatAgent(BaseAgent[Observation, AgentAction]):
             raise RuntimeError(f"Login failed: {login_info['error']}")
         
         print(f"Login successful! User info: {login_info}")
-        self.bot.send_message("RocketChat Agent Listening")
+        print("RocketChat Agent Listening")
         return
 
     async def send_message(self,obs: Observation):
@@ -125,7 +125,10 @@ class RocketChatAgent(BaseAgent[Observation, AgentAction]):
         if obs.last_turn:
             # get rid of x said
             output_msg = obs.last_turn.split(": ", 1)[1].replace('"', '')
-            self.bot.send_message(output_msg)
+            if "Here is the context" not in obs.last_turn:
+                self.bot.send_message(output_msg)
+            else:
+                print(output_msg)
         else:
             print("Sotopia NPC decide to reply Empty String. Chenge to not send.")
         return last_timestamp


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**
Closes #584 

Solved by checking the last_turn message. If the message contains the background then we just print rather than send it. 

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
