### PR TITLE
[CI] Forbid keyword nextcloud

### DIFF
--- a/.github/validate_task_structure.sh
+++ b/.github/validate_task_structure.sh
@@ -89,6 +89,15 @@ for task_dir in *; do
     exit 1
   fi
 
+  # 7. Check for "nextcloud" keyword in all files
+  # TODO: remove this before release. Needed as we recently migrated from nextcloud to onecloud
+  if grep -r -i "nextcloud" . > /dev/null 2>&1; then
+    echo "Error: Found prohibited keyword 'nextcloud' in $task_dir"
+    echo "Files containing 'nextcloud':"
+    grep -r -i "nextcloud" .
+    exit 1
+  fi
+
   poetry run python ../../../.github/validate_dependencies.py "dependencies.yml"
 
   cd -


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

During nextcloud -> onecloud transition period, enforcing CI to check if any PR accidentally uses NextCloud.

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
