### PR TITLE
Infra: remove always restart

### DIFF
--- a/servers/docker-compose.yml
+++ b/servers/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     image: ghcr.io/theagentcompany/servers-rocketchat-npc-data-population:latest
     container_name: redis-stack-npc-data-population
     pull_policy: always
-    restart: always
+    restart: on-failure
     depends_on:
       - redis-stack
     networks:


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**
NPC populate data container should only run only and restart on failure.
---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
