### PR TITLE
[Final check] debug research-answer-questions-on-paper

### DIFF
--- a/workspaces/tasks/research-answer-questions-on-paper/evaluator.py
+++ b/workspaces/tasks/research-answer-questions-on-paper/evaluator.py
@@ -45,7 +45,7 @@ def grade_checkpoint2():
             if len(qa_pair)<2:
                 logging.warning('Analysis sheet corrupted')
                 return 0
-            answer = qa_pair[1].strip().replace("<answer here>","")
+            answer = qa_pair[1].strip()
             score+= 1 if evaluate_with_llm(answer,ref_answers[i]) else 0
             logging.info(f'Question {qa_pair[0]}, Expected Answer: {ref_answers[i]}, Agent Answer: {answer}')
 


### PR DESCRIPTION
(checkpoint-2) the code returns 0 if there's a linebreak at the end of the answer file
Solution: In evaluator.py, in the loop starting Line 41, break the loop if i>10
Also, do not use ".lower()" to convert the answer, which will sometimes cause LLM errors 