### PR TITLE
[server Makefile] Remove and delete even if not running

### DIFF
--- a/servers/Makefile
+++ b/servers/Makefile
@@ -149,8 +149,8 @@ reset-owncloud: init
 
 # api-server
 start-api-server-with-setup: init
-	docker stop api-server
-	docker rm api-server
+	docker stop api-server || true
+	docker rm -f api-server
 	docker run -d \
 		--name api-server \
 		--network host \
@@ -159,8 +159,8 @@ start-api-server-with-setup: init
 		ghcr.io/theagentcompany/servers-api-server:latest
 
 start-api-server: init
-	docker stop api-server
-	docker rm api-server
+	docker stop api-server || true
+	docker rm -f api-server
 	docker run -d \
 		--name api-server \
 		--network host \
@@ -170,10 +170,10 @@ start-api-server: init
 		ghcr.io/theagentcompany/servers-api-server:latest
 
 stop-api-server:
-	docker stop api-server
+	docker stop api-server || true
 
 rm-api-server: stop-api-server
-	docker rm api-server
+	docker rm -f api-server
 
 get-ip:
 	curl ifconfig.me


### PR DESCRIPTION
If api-server is not running (initial state), `make start-api-server-with-setup` would fail because the container doesn't exist

**Give a summary of what the PR does, explaining any non-trivial design decisions**

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
