### PR TITLE
[Makefile] Stop api-server when stop-all

### DIFF
--- a/servers/Makefile
+++ b/servers/Makefile
@@ -24,6 +24,7 @@ start-all: init
 stop-all: init
 	docker compose -p theagentcompany down
 	$(MAKE) rm-rocketchat-volume
+	make stop-api-server
 
 # GitLab
 start-gitlab: init


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Currently `make stop-all` command doesn't stop api-server.

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
