### PR TITLE
[Plane] Download setup.sh before running commands

### DIFF
--- a/servers/plane/Makefile
+++ b/servers/plane/Makefile
@@ -15,18 +15,18 @@ start-plane: download-setup
 	./setup.sh start
 	make reset-plane
 
-start-plane-without-data:
+start-plane-without-data: download-setup
 	./setup.sh start
 
-reset-plane:
+reset-plane: download-setup
 	make stop-plane
 	./plane-app/restore.sh ./
 	make start-plane-without-data
 
-stop-plane:
+stop-plane: download-setup
 	./setup.sh stop
 
-backup-plane:
+backup-plane: download-setup
 	./setup.sh backup
 
 .PHONY: build run


### PR DESCRIPTION
Many Makefile commands under plane folder assume the existence of "setup.sh", which might not be true.

