### PR TITLE
[Evaluation] Estimate cost from trajectory

### DIFF
--- a/evaluation/summarise_results.py
+++ b/evaluation/summarise_results.py
@@ -29,8 +29,7 @@ def calculate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> fl
         return 0.000003 * (prompt_tokens + completion_tokens)
     elif "llama-3.1-70b" in model.lower():
         # assuming hosted on Fireworks AI
-        # FIXME: price not found on Fireworks AI pricing page
-        return 0 * (prompt_tokens + completion_tokens)
+        return 0.0000009 * (prompt_tokens + completion_tokens)
     elif "amazon.nova-pro-v1:0" in model.lower():
         # assuming hosted on Amazon Bedrock
         # https://aws.amazon.com/bedrock/pricing/, accessed 12/11/2024


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Currently, OpenHands only records the cost for gpt-4o model but not others. This PR estimates cost from trajectory, which contains the prompt token and completion token count for each LLM call.

Cross-verification:

OpenHands says gpt-4o evaluation has average step of 16.39 and cost of 0.32 USD.

This PR says gpt-4o evaluation has average step of 14.55 and cost of 1.29 USD.

The steps are close - it's likely due to the nuance between the difference in how OpenHands defines what a "step" is and how we define what a "step" is. The cost is higher, likely because we are using estimates, which doesn't take prompt caching into account.
