### PR TITLE
[CI] Use localhost for evaluator sanity check

### DIFF
--- a/.github/validate_evaluators.sh
+++ b/.github/validate_evaluators.sh
@@ -26,7 +26,9 @@ for task_dir in workspaces/tasks/*/; do
   # Run the container and execute the evaluator
   # The evaluator would almost always say 0 marks granted, but that's
   # fine, we only run it to make sure it at least compiles
-  docker run -e TAC_TEST_MODE=true --rm task-image python_default /utils/eval.py
+  docker run -e TAC_TEST_MODE=true --rm task-image sh -c \
+    "echo '127.0.0.1 the-agent-company.com' >> /etc/hosts; \
+    python_default /utils/eval.py"
 
   # Capture the exit code
   EXIT_CODE=$?


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The CI used to work because `the-agent-company.com` didn't resolve to any IP address. Now it points to a valid IP, which doesn't have the services we have, and that causes network timeout. Solution is to use "127.0.0.1" as `the-agent-company.com` in CI.

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
