### PR TITLE
Decouple evaluator and pre_init files in sde-close-all-issue-on-all-project-under-tac-workspace

### DIFF
--- a/workspaces/tasks/sde-close-all-issue-on-all-project-under-tac-workspace/evaluator.py
+++ b/workspaces/tasks/sde-close-all-issue-on-all-project-under-tac-workspace/evaluator.py
@@ -3,42 +3,8 @@ import logging
 from scoring import Result, Checkpoint
 from common import *
 from typing import List
+from helper import get_plane_all_issue_state
 
-def get_plane_all_issue_state(projects):
-    """
-    Returns a nested dictionary containing issue state counts for each project
-    Return structure:
-    {
-        'JanusGraph': {
-            'Backlog': 0,
-            'Todo': 0,
-            'In Progress': 2,
-            'Done': 4,
-            'Cancelled': 0
-        },
-        'RisingWave': {
-            'Backlog': 0,
-            'Todo': 0,
-            'In Progress': 0,
-            'Done': 6,
-            'Cancelled': 0
-        },
-    }
-    """
-    state_count= {}
-    try:
-        for project in projects:
-            state_map, id_map = get_plane_state_id_dict(project_id=project['id'])
-            state_count[project.get('name')]={}
-            for key in state_map.keys():
-                state_count[project.get('name')][key] = 0
-            issues = get_plane_project_all_issues(project.get('id'))
-            for issue in issues:
-                state_count[project.get('name')][id_map[issue['state']] ] += 1
-        return state_count
-    except Exception as e:
-        logging.warning(f"Get all issues state failed: {e}")
-        return {}
 
 @grader
 def grade_checkpoint1():

--- a/workspaces/tasks/sde-close-all-issue-on-all-project-under-tac-workspace/helper.py
+++ b/workspaces/tasks/sde-close-all-issue-on-all-project-under-tac-workspace/helper.py
@@ -1,0 +1,38 @@
+import logging
+from common import *
+
+def get_plane_all_issue_state(projects):
+    """
+    Returns a nested dictionary containing issue state counts for each project
+    Return structure:
+    {
+        'JanusGraph': {
+            'Backlog': 0,
+            'Todo': 0,
+            'In Progress': 2,
+            'Done': 4,
+            'Cancelled': 0
+        },
+        'RisingWave': {
+            'Backlog': 0,
+            'Todo': 0,
+            'In Progress': 0,
+            'Done': 6,
+            'Cancelled': 0
+        },
+    }
+    """
+    state_count= {}
+    try:
+        for project in projects:
+            state_map, id_map = get_plane_state_id_dict(project_id=project['id'])
+            state_count[project.get('name')]={}
+            for key in state_map.keys():
+                state_count[project.get('name')][key] = 0
+            issues = get_plane_project_all_issues(project.get('id'))
+            for issue in issues:
+                state_count[project.get('name')][id_map[issue['state']] ] += 1
+        return state_count
+    except Exception as e:
+        logging.warning(f"Get all issues state failed: {e}")
+        return {}

--- a/workspaces/tasks/sde-close-all-issue-on-all-project-under-tac-workspace/pre_init.py
+++ b/workspaces/tasks/sde-close-all-issue-on-all-project-under-tac-workspace/pre_init.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 import logging
 from common import *
-from evaluator import get_plane_all_issue_state
+from helper import get_plane_all_issue_state
 
 def write_json(data, filepath):
     try:


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

The encryption effort causes a regression on sde-close-all-issue-on-all-project-under-tac-workspace task because in this task, pre_init.py depends on evaluator.py.

This PR decouples two files and make them both dependent on helper.py.

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
