### PR TITLE
Fix evaluator None value type casting bug

### DIFF
--- a/workspaces/base_image/common.py
+++ b/workspaces/base_image/common.py
@@ -36,7 +36,11 @@ def grader(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         try:
-            return func(*args, **kwargs)
+            result = func(*args, **kwargs)
+            if result is None:
+                logging.warning(f"Grader returns None, using False instead")
+                return False
+            return result
         except Exception as e:
             logging.error(f"Error in {func.__name__}: {str(e)}")
             return False

--- a/workspaces/tasks/pm-ask-for-issue-and-create-in-gitlab/evaluator.py
+++ b/workspaces/tasks/pm-ask-for-issue-and-create-in-gitlab/evaluator.py
@@ -49,7 +49,7 @@ def grade_checkpoint3():
     due_date = issue.get('due_date')
     due_date = due_date and due_date == DUE_DATE
 
-    return milestone and description and due_date
+    return bool(milestone and description and due_date)
 
     
 def grade_checkpoints(trajectory="") -> Result:


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Found this bug during evaluation: if everything in the statement `return milestone and description and due_date` is None, then it returns a None value. We then cast the return value to `int`, which leads to a type error.

Fix is to explicitly cast return value to bool first. Also add a safe guard in the decorator to handle other unexpected "None" return values.

Will republish all task images again after this PR is merged. Will not bump the version 1.0.0 as we haven't formally and publicly released yet.

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
