### PR TITLE
[doc] Add SERVER_HOSTNAME env variable to QUICK START GUIDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Now you can prompt the agent to work on the task. The task instruction is in `/i
 
 > Complete the task in /instruction/task.md
 
-##### Step 2.4: Evaluate the Result
+##### Step 2.4: Grade the Result
 
 ```bash
 LITELLM_API_KEY=<environment_llm_api_key> \

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ A complete list of 175 task images can be found [here](./workspaces/README.md).
 ##### Step 2.2: Initialize the Task Environment
 
 ```bash
+SERVER_HOSTNAME=<hostname, default value is localhost> \
 LITELLM_API_KEY=<environment_llm_api_key> \
 LITELLM_BASE_URL=<environment_llm_base_url> \
 LITELLM_MODEL=<environment_llm_model_name> \

--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -35,6 +35,7 @@ docker run --name <container_name> -it <image_name> /bin/bash
 ### Step 2: Initialize the Task Environment
 
 ```bash
+SERVER_HOSTNAME=<hostname, default value is localhost> \
 LITELLM_API_KEY=<environment_llm_api_key> \
 LITELLM_BASE_URL=<environment_llm_base_url> \
 LITELLM_MODEL=<environment_llm_model_name> \
@@ -46,6 +47,9 @@ reset all the data in dependent services and blocking wait until all health chec
 
 Most importantly, the initialization script would add the server's IP to the `/etc/hosts` file,
 so that the agent can visit the services using the synthetic `the-agent-company.com` hostname.
+
+Your servers could be running locally (in which case `localhost` is used as SERVER_HOSTNAME),
+or remotely (e.g. an AWS host like ec2-ip.us-east-2.compute.amazonaws.com)
 
 ### Step 3: Conduct the Task
 


### PR DESCRIPTION
Task images' `init.sh` support `SERVER_HOSTNAME` env variable which allows users to have servers and agents running on different machines. Adding this option to quick start guide.

**Give a summary of what the PR does, explaining any non-trivial design decisions**

---

Below questions must be answered if you create or modify a task

**Evidence/screenshots of getting full credits in evaluation**



**Steps you took to get full credits (code, chat history, commands)**



**Any files modified/uploaded on the self-hosted services**
