### PR TITLE
fix: ensure newline before adding entry to /etc/hosts

### DIFF
--- a/evaluation/run_eval.py
+++ b/evaluation/run_eval.py
@@ -89,6 +89,7 @@ def init_task_env(runtime: Runtime, hostname: str, env_llm_config: LLMConfig):
         f"LITELLM_API_KEY={env_llm_config.api_key.get_secret_value() if env_llm_config.api_key else None} "
         f"LITELLM_BASE_URL={env_llm_config.base_url} "
         f"LITELLM_MODEL={env_llm_config.model} "
+        "echo "" | sudo tee -a /etc/hosts && "
         "bash /utils/init.sh"
     )
     action = CmdRunAction(command=command)


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions**

Prevents the new entry from being appended to the end of the last existing line in the /etc/hosts file.

**Below questions must be answered if you create or modify a task**

No additional tasks were created or modified.

**Evidence/screenshots of getting full credits in evaluation**

Not applicable.

**Steps you took to get full credits (code, chat history, commands)**

Not applicable.

**Any files modified/uploaded on the self-hosted services**

evaluation/run_eval.py
