### PR TITLE
add VALID_PASSWORD_2 for hr-get-valid-password

### DIFF
--- a/workspaces/tasks/hr-get-valid-password/evaluator.py
+++ b/workspaces/tasks/hr-get-valid-password/evaluator.py
@@ -15,6 +15,7 @@ ROCKETCHAT_URL = "http://the-agent-company.com:3000/home"
 
 USERNAME = "mark_johnson"
 VALID_PASSWORD = "Fl0w3r#Br1ght"
+VALID_PASSWORD_2 = "Fl0w3r#Br1ght."
 
 @grader
 def grade_checkpoint1():
@@ -32,7 +33,7 @@ def grade_checkpoint3():
     with open("/workspace/password.txt", "r") as f:
         password = f.read().strip()
 
-    return password == VALID_PASSWORD
+    return password == VALID_PASSWORD or password == VALID_PASSWORD_2
     
 def grade_checkpoints(trajectory="") -> Result:
     checkpoints: List[Checkpoint] = []


### PR DESCRIPTION
Hi~

In this PR we add a second VALID_PASSWORD for the task hr-get-valid-password.

When running evaluation, we noticed that the password given by the NPC is usually at the end of a sentence, so it comes with a `.`. Some models take that literally and return `Fl0w3r#Br1ght.` instead of `Fl0w3r#Br1ght`.

We think both make sense, so we’re adding the version with the trailing period as another valid answer.

Here are some real trajectories from our model to show this case.

Does this approach make sense to you as well? 🙂

<img width="604" height="381" alt="Clipboard_Screenshot_1756985648" src="https://github.com/user-attachments/assets/0c1f4c41-f042-441c-b7fb-8ec5b8bb9855" />

<img width="946" height="207" alt="Clipboard_Screenshot_1756985726" src="https://github.com/user-attachments/assets/ab0616bb-56e1-4a75-95ef-65d31ef43768" />

